### PR TITLE
Add cam-conf-view-gui.py example app

### DIFF
--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -23,7 +23,6 @@
 
 from __future__ import print_function
 
-from datetime import datetime
 import io
 import logging
 import math
@@ -32,6 +31,10 @@ import re
 import argparse
 import json, codecs
 from collections import OrderedDict
+from datetime import datetime
+import time
+import tzlocal # sudo -H pip install tzlocal # pip2, pip3
+my_timezone = tzlocal.get_localzone()
 
 from PIL import Image, ImageDraw, ImageFont, ImageChops, ImageStat
 
@@ -104,6 +107,9 @@ def get_camera_config_children(childrenarr, savearr):
 def get_camera_config_object(camera_config):
     retdict = OrderedDict()
     retdict['camera_model'] = get_camera_model(camera_config)
+    unixts = time.time()
+    retdict['ts_taken_on'] = unixts
+    retdict['date_taken_on'] = tzlocal.get_localzone().localize(datetime.utcfromtimestamp(unixts), is_dst=None).replace(microsecond=0).isoformat(' ')
     retarray = []
     # # from camera-config-gui-oo.py
     # for child in camera_config.get_children():

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -666,6 +666,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def closeEvent(self, event):
         if self.hasCamInited:
+            # retract lens? might not react here, depending on what the value for capture is, so have to do 1, 0
+            # also, it always sets out of capture on exit, so nevermind
+            #OK, capture = gp.gp_widget_get_child_by_name( self.camera_config, 'capture' )
+            #if OK >= gp.GP_OK:
+            #    capture.set_value(1)
+            #    self.camera.set_config(self.camera_config) # must have this, else value is not effectuated!
+            #    capture.set_value(0)
+            #    self.camera.set_config(self.camera_config) # must have this, else value is not effectuated!
             #~ self.camera_handler.shut_down() # ->
             #~ self.running = False
             self._reset_config()

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -72,28 +72,28 @@ class ImageViewerB(QtWidgets.QWidget):
         #~ if self.mModified:
         if self.m_pixmap:
             painter = QtGui.QPainter(self)
-            painter.begin(self)
+            #~ painter.begin(self)
             painter.translate(self.rect().center())
             painter.scale(self.m_scale, self.m_scale)
-            if self.m_delta:
-                painter.translate(self.m_delta)
+            #if self.m_delta:
+            #    painter.translate(self.m_delta)
             painter.drawPixmap(self.m_rect.topLeft(), self.m_pixmap)
-            painter.end()
+            #~ painter.end()
         #~ painter.drawPixmap(0, 0, self.mPixmap)
         #~ self.drawBackground(painter)
         #~ self.mPixmap = pixmap
         #~ self.mModified = False
-    def mousePressEvent(self, event):
-        self.m_reference = event.pos()
-        QtWidgets.qApp.setOverrideCursor(Qt.ClosedHandCursor)
-        self.setMouseTracking(True)
-    def mouseMoveEvent(self, event):
-        self.m_delta += (event.pos() - self.m_reference) * 1.0/self.m_scale;
-        self.m_reference = event.pos();
-        self.update();
-    def mouseReleaseEvent(self, event):
-        QtWidgets.qApp.restoreOverrideCursor()
-        self.setMouseTracking(False)
+    #def mousePressEvent(self, event):
+    #    self.m_reference = event.pos()
+    #    QtWidgets.qApp.setOverrideCursor(Qt.ClosedHandCursor)
+    #    self.setMouseTracking(True)
+    #def mouseMoveEvent(self, event):
+    #    self.m_delta += (event.pos() - self.m_reference) * 1.0/self.m_scale;
+    #    self.m_reference = event.pos();
+    #    self.update();
+    #def mouseReleaseEvent(self, event):
+    #    QtWidgets.qApp.restoreOverrideCursor()
+    #    self.setMouseTracking(False)
     def setPixmap(self, pix):
         self.m_pixmap = pix
         self.m_rect = self.m_pixmap.rect()
@@ -223,6 +223,9 @@ class MainWindow(QtWidgets.QMainWindow):
         def __init__(self, parent=None):
             super(MainWindow.ScrollAreaWheel, self).__init__(parent)
             self.parent = parent
+            self.m_reference = None
+            self.m_delta = QtCore.QPoint(0,0)
+            self.m_scale = 1.0
         def wheelEvent(self, event):
             #super(MainWindow.ScrollAreaWheel, self).wheelEvent(event)
             #event.accept()
@@ -233,6 +236,25 @@ class MainWindow(QtWidgets.QMainWindow):
             else: self.parent.zoom /= self.parent.zoomfact
             print("wheelEvent", self.wheelDelta, self.parent.zoom)
             self.parent.do_scale()
+        def mousePressEvent(self, event):
+            self.m_reference = event.pos()
+            QtWidgets.qApp.setOverrideCursor(Qt.ClosedHandCursor)
+            self.setMouseTracking(True)
+        def mouseMoveEvent(self, event):
+            self.m_delta = (event.pos() - self.m_reference) * 1.0/self.m_scale;
+            self.m_reference = event.pos();
+            print(self.horizontalScrollBar().value(), self.m_delta.x(), self.verticalScrollBar().value(), self.m_delta.y())
+            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - self.m_delta.x());
+            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - self.m_delta.y());
+            #~ self.update();
+        def mouseReleaseEvent(self, event):
+            QtWidgets.qApp.restoreOverrideCursor()
+            self.setMouseTracking(False)
+        def set_scale(self, s):
+            #~ self.m_scale = s
+            #~ self.update()
+            pass
+
 
     # https://github.com/baoboa/pyqt5/blob/master/examples/widgets/imageviewer.py
     def adjustScrollBar(self, scrollBar, factor):
@@ -275,6 +297,7 @@ class MainWindow(QtWidgets.QMainWindow):
             #~ self.imgwid.resize(self.zoom * self.imglab.pixmap().size()) # stops resize
             #~ self.image_display.resize(self.zoom * self.imglab.pixmap().size())
             print("do_scale", self.zoom * self.pixmap.size())
+            #~ self.image_display.set_scale(self.zoom);
             self.imgwid.set_scale(self.zoom);
             #~ self.imgwid.paintEvent(None)
             #~ self.imgwid.repaint()

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+# python-gphoto2 - Python interface to libgphoto2
+# http://github.com/jim-easterbrook/python-gphoto2
+# Copyright (C) 2014-18  Jim Easterbrook  jim@jim-easterbrook.me.uk
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# another camera config gui, with load/save settings to file, and live view
+# started: sdaau 2019, on with python3-gphoto2, Ubuntu 18.04
+# uses camera-config-gui-oo.py
+
+from __future__ import print_function
+
+from datetime import datetime
+import logging
+import sys, os
+
+from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon
+
+import gphoto2 as gp
+
+THISSCRIPTDIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(1,THISSCRIPTDIR)
+ccgoo = __import__('camera-config-gui-oo')
+
+class MainWindow(QtWidgets.QMainWindow):
+    quit_action = None
+
+    def set_splitter(self, inqtsplittertype, inwidget1, inwidget2):
+        self.splitter1 = QtWidgets.QSplitter(Qt.Horizontal)
+        self.splitter1.addWidget(inwidget1)
+        self.splitter1.addWidget(inwidget2)
+
+    def create_main_menu(self):
+        self.mainMenu = self.menuBar()
+        self.fileMenu = self.mainMenu.addMenu('File')
+        # actions
+        self.load_action = QtWidgets.QAction('Load settings', self)
+        self.load_action.setShortcuts(['Ctrl+L'])
+        self.load_action.triggered.connect(self.load_settings)
+        self.save_action = QtWidgets.QAction('Save settings', self)
+        self.save_action.setShortcuts(['Ctrl+S', 'Ctrl+W'])
+        self.save_action.triggered.connect(self.save_settings)
+        self.fileMenu.addAction(self.load_action)
+        self.fileMenu.addAction(self.save_action)
+        self.fileMenu.addAction(self.quit_action)
+        self.viewMenu = self.mainMenu.addMenu('View')
+        self.zoomorig_action = QtWidgets.QAction('Zoom original', self)
+        self.zoomorig_action.setShortcuts(['Ctrl+Z'])
+        self.zoomorig_action.triggered.connect(self.zoom_original)
+        self.zoomfitview_action = QtWidgets.QAction('Zoom to fit view', self)
+        self.zoomfitview_action.setShortcuts(['Ctrl+F'])
+        self.zoomfitview_action.triggered.connect(self.zoom_fit_view)
+        self.switchlayout_action = QtWidgets.QAction('Switch Layout', self)
+        self.switchlayout_action.setShortcuts(['Ctrl-A'])
+        self.switchlayout_action.triggered.connect(self.switch_layout)
+        self.viewMenu.addAction(self.zoomorig_action)
+        self.viewMenu.addAction(self.zoomfitview_action)
+        self.viewMenu.addAction(self.switchlayout_action)
+
+    def __init__(self):
+        self.do_init = QtCore.QEvent.registerEventType()
+        QtWidgets.QMainWindow.__init__(self)
+        self.setWindowTitle("Camera config cam-conf-view-gui.py")
+        self.setMinimumWidth(600)
+        # quit shortcut
+        self.quit_action = QtWidgets.QAction('Quit', self)
+        self.quit_action.setShortcuts(['Ctrl+Q', 'Ctrl+W'])
+        self.quit_action.setStatusTip('Exit application')
+        self.quit_action.triggered.connect(QtWidgets.qApp.closeAllWindows)
+        self.addAction(self.quit_action)
+        # main menu
+        self.create_main_menu()
+        # main widget
+        self.widget = QtWidgets.QWidget()
+        self.widget.setLayout(QtWidgets.QGridLayout())
+        self.setCentralWidget(self.widget)
+        # frames
+        self.frameview = QtWidgets.QFrame(self)
+        self.frameview.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.frameconf = QtWidgets.QFrame(self)
+        self.frameconf.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.frameconf.setStyleSheet("padding: 0;")
+        self.frameconflayout = QtWidgets.QHBoxLayout(self.frameconf)
+        self.frameconflayout.setSpacing(0);
+        self.frameconflayout.setContentsMargins(0,0,0,0);
+        self.scrollconf = QtWidgets.QScrollArea(self)
+        self.scrollconf.setWidgetResizable(True)
+        self.contentconf = QtWidgets.QWidget()
+        self.scrollconf.setWidget(self.contentconf)
+        self.frameconflayout.addWidget(self.scrollconf)
+
+        self.set_splitter(Qt.Horizontal, self.frameview, self.frameconf)
+        self.widget.layout().addWidget(self.splitter1, 1, 1)
+        self.widget.layout().setContentsMargins(2,2,2,2);
+
+        # defer full initialisation (slow operation) until gui is visible
+        self.camera = gp.Camera()
+        QtWidgets.QApplication.postEvent(
+            self, QtCore.QEvent(self.do_init), Qt.LowEventPriority - 1)
+
+    def event(self, event):
+        if event.type() != self.do_init:
+            return QtWidgets.QMainWindow.event(self, event)
+        event.accept()
+        QtWidgets.QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            self.initialise()
+        finally:
+            QtWidgets.QApplication.restoreOverrideCursor()
+        return True
+
+    def initialise(self):
+        # get camera config tree
+        self.camera.init()
+        self.camera_config = self.camera.get_config()
+        # create corresponding tree of tab widgets
+        self.setWindowTitle(self.camera_config.get_label())
+        #~ self.centralWidget().layout().addWidget(SectionWidget(
+            #~ self.config_changed, self.camera_config), 0, 0, 1, 3)
+
+    def config_changed(self):
+        self.apply_button.setEnabled(True)
+
+    def apply_changes(self):
+        self.camera.set_config(self.camera_config)
+        QtWidgets.qApp.closeAllWindows()
+
+    def load_settings(self):
+        print("load_settings")
+
+    def save_settings(self):
+        print("save_settings")
+
+    def zoom_original(self):
+        print("zoom_original")
+
+    def zoom_fit_view(self):
+        print("zoom_fit_view")
+
+    def switch_layout(self):
+        print("switch_layout")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format='%(levelname)s: %(name)s: %(message)s', level=logging.WARNING)
+    gp.check_result(gp.use_python_logging())
+    app = QtWidgets.QApplication([])
+    main = MainWindow()
+    main.show()
+    sys.exit(app.exec_())
+
+

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -66,6 +66,20 @@ def get_camera_model(camera_config):
         camera_model = ''
     return camera_model
 
+def get_gphoto2_CameraWidgetType_string(innumenum):
+    switcher = {
+        0: "GP_WIDGET_WINDOW",
+        1: "GP_WIDGET_SECTION",
+        2: "GP_WIDGET_TEXT",
+        3: "GP_WIDGET_RANGE",
+        4: "GP_WIDGET_TOGGLE",
+        5: "GP_WIDGET_RADIO",
+        6: "GP_WIDGET_MENU",
+        7: "GP_WIDGET_BUTTON",
+        8: "GP_WIDGET_DATE"
+    }
+    return switcher.get(innumenum, "Invalid camwidget type")
+
 def get_camera_config_children(childrenarr, savearr):
     for child in childrenarr:
         tmpdict = OrderedDict()
@@ -73,11 +87,18 @@ def get_camera_config_children(childrenarr, savearr):
         tmpdict['name'] = child.get_name()
         tmpdict['label'] = child.get_label()
         tmpdict['type'] = child.get_type()
+        tmpdict['typestr'] = get_gphoto2_CameraWidgetType_string( tmpdict['type'] )
         if ((tmpdict['type'] == gp.GP_WIDGET_RADIO) or (tmpdict['type'] == gp.GP_WIDGET_MENU)):
             tmpdict['count_choices'] = child.count_choices()
+            tmpchoices = []
+            for choice in child.get_choices():
+                tmpchoices.append(choice)
+            tmpdict['choices'] = ",".join(tmpchoices)
         if (child.count_children() > 0):
             tmpdict['children'] = []
             get_camera_config_children(child.get_children(), tmpdict['children'])
+        else:
+            tmpdict['value'] = child.get_value()
         savearr.append(tmpdict)
 
 def get_camera_config_object(camera_config):

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -97,6 +97,10 @@ def get_formatted_ts(inunixts=None):
         unixts = time.time()
     else:
         unixts = inunixts
+    # note, for unixts as float:
+    # Python3 produces 1548278272.2560065 (7 decimals), Python2 produces 1548278269.337123 (6 decimals)
+    # so force rounding to 6 decimals:
+    unixts = round(unixts,6)
     tzlocalts = tzlocal.get_localzone().localize(datetime.utcfromtimestamp(unixts), is_dst=None).replace(microsecond=0)
     isots = tzlocalts.isoformat(' ')
     fsuffts = tzlocalts.strftime('%Y%m%d_%H%M%S') # file suffix timestamp
@@ -801,7 +805,8 @@ def getSaveCamConfJson(args):
         #print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
         camconfobj = get_camera_config_object(camera_config)
         with open(jsonfile, 'wb') as f: # SO:14870531
-            json.dump(camconfobj, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2)
+            # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
+            json.dump(camconfobj, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
         print("Saved config to {}; exiting.".format(jsonfile))
         sys.exit(0)
     else: # camera not inited
@@ -842,7 +847,8 @@ def copyFilterCamConfJson(args):
     ))
     # save
     with open(outjsonfile, 'wb') as f: # SO:14870531
-        json.dump(retdict, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2)
+        # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
+        json.dump(retdict, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
     print("Saved filtered copy to output file {}".format(outjsonfile))
     sys.exit(0)
 

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -764,6 +764,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.camera.exit()
             #~ self.ch_thread.quit()
             #~ self.ch_thread.wait()
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.settings.setValue("windowState", self.saveState())
         return super(MainWindow, self).closeEvent(event)
 
     def _set_config(self):
@@ -946,6 +948,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.do_next = QtCore.QEvent.registerEventType()
         self.running = False
         QtWidgets.QMainWindow.__init__(self)
+        self.settings = QtCore.QSettings("MyCompany", APPNAME) # SO:11352157
+        if not self.settings.value("geometry") == None:
+            self.restoreGeometry(self.settings.value("geometry"))
+        if not self.settings.value("windowState") == None:
+            self.restoreState(self.settings.value("windowState"))
         self.setWindowTitle("Camera config {}".format(APPNAME))
         self.setMinimumWidth(1000)
         self.setMinimumHeight(600)

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -160,6 +160,22 @@ def get_camera_config_object(camera_config):
     print("Parsed camera config: {} properties total, of which {} read-write and {} read-only; with {}".format(propcount.numtot, propcount.numrw, propcount.numro, excstr))
     return retdict
 
+def put_camera_capture_preview_mirror(camera, camera_config, camera_model):
+    if camera_model == 'unknown':
+        # find the capture size class config item
+        # need to set this on my Canon 350d to get preview to work at all
+        OK, capture_size_class = gp.gp_widget_get_child_by_name(
+            camera_config, 'capturesizeclass')
+        if OK >= gp.GP_OK:
+            # set value
+            value = capture_size_class.get_choice(2)
+            capture_size_class.set_value(value)
+            # set config
+            camera.set_config(camera_config)
+    else:
+        # put camera into preview mode to raise mirror
+        print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+
 # SO:35514531 - see also SO:46934526, 40683840, 9475772, https://github.com/baoboa/pyqt5/blob/master/examples/widgets/imageviewer.py
 class PhotoViewer(QtWidgets.QGraphicsView):
     photoClicked = QtCore.pyqtSignal(QtCore.QPoint)
@@ -561,20 +577,21 @@ class MainWindow(QtWidgets.QMainWindow):
             #     print('No camera model info')
             #     self.camera_model = ''
             self.camera_model = get_camera_model(self.camera_config)
-            if self.camera_model == 'unknown':
-                # find the capture size class config item
-                # need to set this on my Canon 350d to get preview to work at all
-                OK, capture_size_class = gp.gp_widget_get_child_by_name(
-                    self.camera_config, 'capturesizeclass')
-                if OK >= gp.GP_OK:
-                    # set value
-                    value = capture_size_class.get_choice(2)
-                    capture_size_class.set_value(value)
-                    # set config
-                    self.camera.set_config(self.camera_config)
-            else:
-                # put camera into preview mode to raise mirror
-                print(gp.gp_camera_capture_preview(self.camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+            # if self.camera_model == 'unknown':
+            #     # find the capture size class config item
+            #     # need to set this on my Canon 350d to get preview to work at all
+            #     OK, capture_size_class = gp.gp_widget_get_child_by_name(
+            #         self.camera_config, 'capturesizeclass')
+            #     if OK >= gp.GP_OK:
+            #         # set value
+            #         value = capture_size_class.get_choice(2)
+            #         capture_size_class.set_value(value)
+            #         # set config
+            #         self.camera.set_config(self.camera_config)
+            # else:
+            #     # put camera into preview mode to raise mirror
+            #     print(gp.gp_camera_capture_preview(self.camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+            put_camera_capture_preview_mirror(self.camera, self.camera_config, self.camera_model)
         self.updateStatusBar()
 
     def initialise(self):
@@ -743,6 +760,7 @@ def getSaveCamConfJson(args):
         #else:
         #    # put camera into preview mode to raise mirror
         #    print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+        #~ put_camera_capture_preview_mirror(camera, camera_config, camera_model)
         print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
         camconfobj = get_camera_config_object(camera_config)
         with open(jsonfile, 'wb') as f: # SO:14870531
@@ -791,20 +809,21 @@ def loadSetCamConfJson(args):
         #     print('No camera model info')
         #     camera_model = ''
         camera_model = get_camera_model(camera_config)
-        if camera_model == 'unknown':
-            # find the capture size class config item
-            # need to set this on my Canon 350d to get preview to work at all
-            OK, capture_size_class = gp.gp_widget_get_child_by_name(
-                camera_config, 'capturesizeclass')
-            if OK >= gp.GP_OK:
-                # set value
-                value = capture_size_class.get_choice(2)
-                capture_size_class.set_value(value)
-                # set config
-                camera.set_config(camera_config)
-        else:
-            # put camera into preview mode to raise mirror
-            print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+        # if camera_model == 'unknown':
+        #     # find the capture size class config item
+        #     # need to set this on my Canon 350d to get preview to work at all
+        #     OK, capture_size_class = gp.gp_widget_get_child_by_name(
+        #         camera_config, 'capturesizeclass')
+        #     if OK >= gp.GP_OK:
+        #         # set value
+        #         value = capture_size_class.get_choice(2)
+        #         capture_size_class.set_value(value)
+        #         # set config
+        #         camera.set_config(camera_config)
+        # else:
+        #     # put camera into preview mode to raise mirror
+        #     print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+        put_camera_capture_preview_mirror(camera, camera_config, camera_model)
     else: # camera not inited
         print("Sorry, no camera present, cannot execute command; exiting.")
         sys.exit(1)

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -301,24 +301,28 @@ class MainWindow(QtWidgets.QMainWindow):
     def do_scale(self):
         #if (self.imglab.pixmap()):
         if (self.pixmap):
-            #~ self.imgwid.resize(self.zoom * self.imglab.pixmap().size()) # stops resize
-            #~ self.image_display.resize(self.zoom * self.imglab.pixmap().size())
-            print("do_scale", self.zoom * self.pixmap.size())
-            #~ self.image_display.set_scale(self.zoom);
-            self.imgwid.set_scale(self.zoom);
-            #~ self.imgwid.paintEvent(None)
-            #~ self.imgwid.repaint()
-            self.imgwid.resize(self.zoom * self.pixmap.size()) #setFixedSize  must be for resize (also .resize works), if setWidgetResizable(False) # also works on its own in that case, but does not stay put
-            if self.image_display.m_wheelevent:
-                wex, iwtlx = self.image_display.m_wheelevent.globalX(), self.mapToGlobal(self.imgwid.rect().topLeft()).x()
-                wey, iwtly = self.image_display.m_wheelevent.globalY(), self.mapToGlobal(self.imgwid.rect().topLeft()).y()
-                self.wheeldx = (wex - iwtlx)*abs(self.imgwid.m_scalechange)
-                self.wheeldy = (wey - iwtly)*abs(self.imgwid.m_scalechange)
-                print("wex", wex, iwtlx, self.wheeldx)
-                sys.stdout.flush()
+            orig_size = self.pixmap.size()
+        else:
+            orig_size = self.imgwid.size()
 
-                self.image_display.horizontalScrollBar().setValue(self.image_display.horizontalScrollBar().value() + self.wheeldx);
-                self.image_display.verticalScrollBar().setValue(self.image_display.verticalScrollBar().value() + self.wheeldy);
+        #~ self.imgwid.resize(self.zoom * self.imglab.pixmap().size()) # stops resize
+        #~ self.image_display.resize(self.zoom * self.imglab.pixmap().size())
+        print("do_scale", self.zoom * orig_size)
+        #~ self.image_display.set_scale(self.zoom);
+        self.imgwid.set_scale(self.zoom);
+        #~ self.imgwid.paintEvent(None)
+        #~ self.imgwid.repaint()
+        self.imgwid.resize(self.zoom * orig_size) #setFixedSize  must be for resize (also .resize works), if setWidgetResizable(False) # also works on its own in that case, but does not stay put
+        if self.image_display.m_wheelevent:
+            wex, iwtlx = self.image_display.m_wheelevent.globalX(), self.mapToGlobal(self.imgwid.rect().topLeft()).x()
+            wey, iwtly = self.image_display.m_wheelevent.globalY(), self.mapToGlobal(self.imgwid.rect().topLeft()).y()
+            self.wheeldx = (wex - iwtlx)*abs(self.imgwid.m_scalechange)
+            self.wheeldy = (wey - iwtly)*abs(self.imgwid.m_scalechange)
+            print("wex", wex, iwtlx, self.wheeldx)
+            sys.stdout.flush()
+
+            self.image_display.horizontalScrollBar().setValue(self.image_display.horizontalScrollBar().value() + self.wheeldx);
+            self.image_display.verticalScrollBar().setValue(self.image_display.verticalScrollBar().value() + self.wheeldy);
             # # scaled pixmap is enough
             # pixmap = self.pixmap.scaled(
             #     #~ #self.image_display.viewport().size(),
@@ -339,7 +343,8 @@ class MainWindow(QtWidgets.QMainWindow):
         #~ self.imgwid = QtWidgets.QWidget()
         self.imgwid = ImageViewerB()
         self.imgwid.setContentsMargins(0,0,0,0);
-        self.imgwid.setStyleSheet("background-color: rgb(255,0,0); margin:5px; border:1px solid rgb(0, 255, 0); ")
+        #self.imgwid.setStyleSheet("background-color: rgb(255,0,0); margin:5px; border:1px solid rgb(0, 255, 0); ")
+        self.imgwid.setStyleSheet("background-color: qradialgradient(cx: 0.5, cy: 0.5, radius: 2, fx: 0.5, fy: 1, stop: 0 rgba(255,30,30,255), stop: 0.2 rgba(255,30,30,144), stop: 0.4 rgba(255,30,30,32)); margin:5px; border:1px solid rgb(0, 255, 0); ")
         self.image_display.setWidget(self.imgwid)
         # self.image_label_lay = QtWidgets.QGridLayout(self.imgwid)
         # self.image_label_lay.setSpacing(0);
@@ -394,6 +399,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.wheeldx = 0
         self.wheeldy = 0
         self.do_init = QtCore.QEvent.registerEventType()
+        self.pixmap = None
         QtWidgets.QMainWindow.__init__(self)
         self.setWindowTitle("Camera config cam-conf-view-gui.py")
         self.setMinimumWidth(1000)

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -61,6 +61,9 @@ class ImageViewerB(QtWidgets.QWidget):
         #~ self.setGeometry(5, 5, 30, 30)
         #~ self.setMinimumSize(30, 20)
         #~ self.installEventFilter(self)
+        tempmap = QtGui.QPixmap("grad.png")
+        #~ self.new_image(tempmap)
+        self.setPixmap(tempmap)
         self.show()
         #~ self.repaint()
     def eventFilter(self, source, event):
@@ -313,12 +316,33 @@ class MainWindow(QtWidgets.QMainWindow):
         #~ self.imgwid.paintEvent(None)
         #~ self.imgwid.repaint()
         self.imgwid.resize(self.zoom * orig_size) #setFixedSize  must be for resize (also .resize works), if setWidgetResizable(False) # also works on its own in that case, but does not stay put
+
+# printout:
+# iwtlx does NOT change, remains on 50 always (imgwid.rect.TopLeft via self.mapToGlobal)
+# wex does sometimes - but it is the location of mouse pointer
+# 3rd arg (iwtlxw) does change, which is imgwid.rect.TopLeft via self.imgwid.mapToGlobal
+# (4th arg is wheeldx):
+
+#~ wex 281 50 119 46.19999999999999
+#~ wex 281 50 119 46.19999999999999
+#~ wex 281 50 116 46.19999999999999
+#~ wex 281 50 106 55.44
+#~ wex 281 50 84 66.528
+#~ wex 310 50 26 89.85599999999998
+#~ wex 310 50 -55 89.85599999999998
+#~ wex 310 50 -98 89.85599999999998
+#~ wex 310 50 -187 107.82719999999999
+#~ wex 310 50 -294 129.39263999999997
+#~ wex 310 50 -423 155.27116799999996
+#~ wex 310 50 -578 186.32540159999994
+#~ wex 310 50 -764 223.59048192
+
         if self.image_display.m_wheelevent:
             wex, iwtlx = self.image_display.m_wheelevent.globalX(), self.mapToGlobal(self.imgwid.rect().topLeft()).x()
             wey, iwtly = self.image_display.m_wheelevent.globalY(), self.mapToGlobal(self.imgwid.rect().topLeft()).y()
             self.wheeldx = (wex - iwtlx)*abs(self.imgwid.m_scalechange)
             self.wheeldy = (wey - iwtly)*abs(self.imgwid.m_scalechange)
-            print("wex", wex, iwtlx, self.wheeldx)
+            print("wex", wex, iwtlx, self.imgwid.mapToGlobal(self.imgwid.m_rect.topLeft()).x(), self.wheeldx)
             sys.stdout.flush()
 
             self.image_display.horizontalScrollBar().setValue(self.image_display.horizontalScrollBar().value() + self.wheeldx);
@@ -447,6 +471,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.set_splitter(Qt.Horizontal, self.frameview, self.frameconf)
 
         # defer full initialisation (slow operation) until gui is visible
+        #~ tempmap = QtGui.QPixmap("grad.png")
+        #~ self.new_image(tempmap)
+
         self.camera = gp.Camera()
         QtWidgets.QApplication.postEvent(
             self, QtCore.QEvent(self.do_init), Qt.LowEventPriority - 1)

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -564,33 +564,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.camera_config = self.camera.get_config()
             # from CameraHandler::Init:
             self.old_capturetarget = None
-            # # get the camera model
-            # OK, camera_model = gp.gp_widget_get_child_by_name(
-            #     self.camera_config, 'cameramodel')
-            # if OK < gp.GP_OK:
-            #     OK, camera_model = gp.gp_widget_get_child_by_name(
-            #         self.camera_config, 'model')
-            # if OK >= gp.GP_OK:
-            #     self.camera_model = camera_model.get_value()
-            #     print('Camera model:', self.camera_model)
-            # else:
-            #     print('No camera model info')
-            #     self.camera_model = ''
+            # get the camera model
             self.camera_model = get_camera_model(self.camera_config)
-            # if self.camera_model == 'unknown':
-            #     # find the capture size class config item
-            #     # need to set this on my Canon 350d to get preview to work at all
-            #     OK, capture_size_class = gp.gp_widget_get_child_by_name(
-            #         self.camera_config, 'capturesizeclass')
-            #     if OK >= gp.GP_OK:
-            #         # set value
-            #         value = capture_size_class.get_choice(2)
-            #         capture_size_class.set_value(value)
-            #         # set config
-            #         self.camera.set_config(self.camera_config)
-            # else:
-            #     # put camera into preview mode to raise mirror
-            #     print(gp.gp_camera_capture_preview(self.camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
             put_camera_capture_preview_mirror(self.camera, self.camera_config, self.camera_model)
         self.updateStatusBar()
 
@@ -731,37 +706,7 @@ def getSaveCamConfJson(args):
         #    pass
     if hasCamInited:
         camera_config = camera.get_config() # may print: WARNING: gphoto2: (b'_get_config [config.c:7649]') b"Type of property 'Owner Name' expected: 0x4002 got: 0x0000"
-        # from CameraHandler::Init:
-        #~ old_capturetarget = None
-        # get the camera model
-        #OK, camera_model = gp.gp_widget_get_child_by_name(
-        #    camera_config, 'cameramodel')
-        #if OK < gp.GP_OK:
-        #    OK, camera_model = gp.gp_widget_get_child_by_name(
-        #        camera_config, 'model')
-        #if OK >= gp.GP_OK:
-        #    camera_model = camera_model.get_value()
-        #    print('Camera model:', camera_model)
-        #else:
-        #    print('No camera model info')
-        #    camera_model = ''
-        #~ camera_model = get_camera_model(camera_config)
-        #if camera_model == 'unknown':
-        #    # find the capture size class config item
-        #    # need to set this on my Canon 350d to get preview to work at all
-        #    OK, capture_size_class = gp.gp_widget_get_child_by_name(
-        #        camera_config, 'capturesizeclass')
-        #    if OK >= gp.GP_OK:
-        #        # set value
-        #        value = capture_size_class.get_choice(2)
-        #        capture_size_class.set_value(value)
-        #        # set config
-        #        camera.set_config(camera_config)
-        #else:
-        #    # put camera into preview mode to raise mirror
-        #    print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
-        #~ put_camera_capture_preview_mirror(camera, camera_config, camera_model)
-        print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
+        #print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
         camconfobj = get_camera_config_object(camera_config)
         with open(jsonfile, 'wb') as f: # SO:14870531
             json.dump(camconfobj, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2)
@@ -796,33 +741,8 @@ def loadSetCamConfJson(args):
         camera_config = camera.get_config()
         # from CameraHandler::Init:
         old_capturetarget = None
-        # # get the camera model
-        # OK, camera_model = gp.gp_widget_get_child_by_name(
-        #     camera_config, 'cameramodel')
-        # if OK < gp.GP_OK:
-        #     OK, camera_model = gp.gp_widget_get_child_by_name(
-        #         camera_config, 'model')
-        # if OK >= gp.GP_OK:
-        #     camera_model = camera_model.get_value()
-        #     print('Camera model:', camera_model)
-        # else:
-        #     print('No camera model info')
-        #     camera_model = ''
+        # get the camera model
         camera_model = get_camera_model(camera_config)
-        # if camera_model == 'unknown':
-        #     # find the capture size class config item
-        #     # need to set this on my Canon 350d to get preview to work at all
-        #     OK, capture_size_class = gp.gp_widget_get_child_by_name(
-        #         camera_config, 'capturesizeclass')
-        #     if OK >= gp.GP_OK:
-        #         # set value
-        #         value = capture_size_class.get_choice(2)
-        #         capture_size_class.set_value(value)
-        #         # set config
-        #         camera.set_config(camera_config)
-        # else:
-        #     # put camera into preview mode to raise mirror
-        #     print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
         put_camera_capture_preview_mirror(camera, camera_config, camera_model)
     else: # camera not inited
         print("Sorry, no camera present, cannot execute command; exiting.")

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -320,7 +320,7 @@ class MainWindow(QtWidgets.QMainWindow):
 # printout:
 # iwtlx does NOT change, remains on 50 always (imgwid.rect.TopLeft via self.mapToGlobal)
 # wex does sometimes - but it is the location of mouse pointer
-# 3rd arg (iwtlxw) does change, which is imgwid.rect.TopLeft via self.imgwid.mapToGlobal
+# 3rd arg (iwtlxiw) does change, which is imgwid.rect.TopLeft via self.imgwid.mapToGlobal
 # (4th arg is wheeldx):
 
 #~ wex 281 50 119 46.19999999999999
@@ -337,12 +337,20 @@ class MainWindow(QtWidgets.QMainWindow):
 #~ wex 310 50 -578 186.32540159999994
 #~ wex 310 50 -764 223.59048192
 
+# currently, do_scale in respect to iwtlx is "late" - if I go three times forward, starting to go back will again go forward for three times, before actually turning back
+# same thing for iwtlxiw
+# in both cases, when it gets "late", occasionally the SVG background shows, meaning either the image or the background are not scaled right
+
         if self.image_display.m_wheelevent:
             wex, iwtlx = self.image_display.m_wheelevent.globalX(), self.mapToGlobal(self.imgwid.rect().topLeft()).x()
             wey, iwtly = self.image_display.m_wheelevent.globalY(), self.mapToGlobal(self.imgwid.rect().topLeft()).y()
+            iwtlxiw = self.imgwid.mapToGlobal(self.imgwid.m_rect.topLeft()).x()
+            iwtlyiw = self.imgwid.mapToGlobal(self.imgwid.m_rect.topLeft()).y()
+
+            #self.wheeldx = (wex - iwtlx)*abs(self.imgwid.m_scalechange)
             self.wheeldx = (wex - iwtlx)*abs(self.imgwid.m_scalechange)
             self.wheeldy = (wey - iwtly)*abs(self.imgwid.m_scalechange)
-            print("wex", wex, iwtlx, self.imgwid.mapToGlobal(self.imgwid.m_rect.topLeft()).x(), self.wheeldx)
+            print("wex", wex, iwtlx, iwtlxiw, self.wheeldx)
             sys.stdout.flush()
 
             self.image_display.horizontalScrollBar().setValue(self.image_display.horizontalScrollBar().value() + self.wheeldx);

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -30,6 +30,7 @@ import math
 import sys, os
 import re
 import argparse
+import json
 
 from PIL import Image, ImageDraw, ImageFont, ImageChops, ImageStat
 
@@ -109,7 +110,7 @@ class PhotoViewer(QtWidgets.QGraphicsView):
             #self._zoom = 0
 
     def setPhoto(self, pixmap=None):
-        self._zoom = 0
+        #self._zoom = 0
         if pixmap and not pixmap.isNull():
             self._empty = False
             #self.setDragMode(QtWidgets.QGraphicsView.ScrollHandDrag)
@@ -615,20 +616,23 @@ def getSaveCamConfJson(args):
         else:
             print('No camera model info')
             camera_model = ''
-        if camera_model == 'unknown':
-            # find the capture size class config item
-            # need to set this on my Canon 350d to get preview to work at all
-            OK, capture_size_class = gp.gp_widget_get_child_by_name(
-                camera_config, 'capturesizeclass')
-            if OK >= gp.GP_OK:
-                # set value
-                value = capture_size_class.get_choice(2)
-                capture_size_class.set_value(value)
-                # set config
-                camera.set_config(camera_config)
-        else:
-            # put camera into preview mode to raise mirror
-            print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+        #if camera_model == 'unknown':
+        #    # find the capture size class config item
+        #    # need to set this on my Canon 350d to get preview to work at all
+        #    OK, capture_size_class = gp.gp_widget_get_child_by_name(
+        #        camera_config, 'capturesizeclass')
+        #    if OK >= gp.GP_OK:
+        #        # set value
+        #        value = capture_size_class.get_choice(2)
+        #        capture_size_class.set_value(value)
+        #        # set config
+        #        camera.set_config(camera_config)
+        #else:
+        #    # put camera into preview mode to raise mirror
+        #    print(gp.gp_camera_capture_preview(camera)) # [0, <Swig Object of type 'CameraFile *' at 0x7fb5a0044a40>]
+        print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
+        print("Saved config to {}; exiting.".format(jsonfile))
+        sys.exit(0)
     else: # camera not inited
         print("Sorry, no camera present, cannot execute command; exiting.")
         sys.exit(1)

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -66,21 +66,37 @@ def get_camera_model(camera_config):
         camera_model = ''
     return camera_model
 
+def get_camera_config_children(childrenarr, savearr):
+    for child in childrenarr:
+        tmpdict = OrderedDict()
+        tmpdict['ro'] = child.get_readonly()
+        tmpdict['name'] = child.get_name()
+        tmpdict['label'] = child.get_label()
+        tmpdict['type'] = child.get_type()
+        if ((tmpdict['type'] == gp.GP_WIDGET_RADIO) or (tmpdict['type'] == gp.GP_WIDGET_MENU)):
+            tmpdict['count_choices'] = child.count_choices()
+        if (child.count_children() > 0):
+            tmpdict['children'] = []
+            get_camera_config_children(child.get_children(), tmpdict['children'])
+        savearr.append(tmpdict)
+
 def get_camera_config_object(camera_config):
     retdict = OrderedDict()
     retdict['camera_model'] = get_camera_model(camera_config)
     retarray = []
-    # from camera-config-gui-oo.py
-    for child in camera_config.get_children():
-        tmpdict = OrderedDict()
-        tmpdict['ro'] = child.get_readonly()
-        tmpdict['label'] = child.get_label()
-        tmpdict['name'] = child.get_name()
-        tmpdict['type'] = child.get_type()
-        if ((tmpdict['type'] == gp.GP_WIDGET_RADIO) or (tmpdict['type'] == gp.GP_WIDGET_MENU)):
-            tmpdict['count_choices'] = child.count_choices()
-        retarray.append(tmpdict)
-    retdict['config'] = retarray
+    # # from camera-config-gui-oo.py
+    # for child in camera_config.get_children():
+    #     tmpdict = OrderedDict()
+    #     tmpdict['ro'] = child.get_readonly()
+    #     tmpdict['label'] = child.get_label()
+    #     tmpdict['name'] = child.get_name()
+    #     tmpdict['type'] = child.get_type()
+    #     if ((tmpdict['type'] == gp.GP_WIDGET_RADIO) or (tmpdict['type'] == gp.GP_WIDGET_MENU)):
+    #         tmpdict['count_choices'] = child.count_choices()
+    #     retarray.append(tmpdict)
+    # retdict['config'] = retarray
+    retdict['children'] = []
+    get_camera_config_children(camera_config.get_children(), retdict['children'])
     return retdict
 
 # SO:35514531 - see also SO:46934526, 40683840, 9475772, https://github.com/baoboa/pyqt5/blob/master/examples/widgets/imageviewer.py
@@ -635,21 +651,22 @@ def getSaveCamConfJson(args):
         #if type(ex) == gp.GPhoto2Error: #gphoto2.GPhoto2Error:
         #    pass
     if hasCamInited:
-        camera_config = camera.get_config()
+        camera_config = camera.get_config() # may print: WARNING: gphoto2: (b'_get_config [config.c:7649]') b"Type of property 'Owner Name' expected: 0x4002 got: 0x0000"
         # from CameraHandler::Init:
-        old_capturetarget = None
+        #~ old_capturetarget = None
         # get the camera model
-        OK, camera_model = gp.gp_widget_get_child_by_name(
-            camera_config, 'cameramodel')
-        if OK < gp.GP_OK:
-            OK, camera_model = gp.gp_widget_get_child_by_name(
-                camera_config, 'model')
-        if OK >= gp.GP_OK:
-            camera_model = camera_model.get_value()
-            print('Camera model:', camera_model)
-        else:
-            print('No camera model info')
-            camera_model = ''
+        #OK, camera_model = gp.gp_widget_get_child_by_name(
+        #    camera_config, 'cameramodel')
+        #if OK < gp.GP_OK:
+        #    OK, camera_model = gp.gp_widget_get_child_by_name(
+        #        camera_config, 'model')
+        #if OK >= gp.GP_OK:
+        #    camera_model = camera_model.get_value()
+        #    print('Camera model:', camera_model)
+        #else:
+        #    print('No camera model info')
+        #    camera_model = ''
+        #~ camera_model = get_camera_model(camera_config)
         #if camera_model == 'unknown':
         #    # find the capture size class config item
         #    # need to set this on my Canon 350d to get preview to work at all
@@ -727,7 +744,7 @@ def loadSetCamConfJson(args):
 def main():
     # set up logging
     logging.basicConfig(
-        format='%(levelname)s: %(name)s: %(message)s', level=logging.WARNING)
+        format='%(filename)s:%(lineno)d %(levelname)s: %(name)s: %(message)s', level=logging.WARNING)
     gp.check_result(gp.use_python_logging())
 
     # command line argument parser

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -293,6 +293,205 @@ def copy_json_filter_props(inarr, outarr, inpropcount, outpropcount, jsonfilters
                 copy_json_filter_props(inchild['children'], outarr, inpropcount, outpropcount, jsonfilters)
 
 
+def getSaveCamConfJson(args):
+    if (not(args.save_cam_conf_json)):
+        print("getSaveCamConfJson: Sorry, unusable/empty output .json filename; aborting")
+        sys.exit(1)
+    jsonfile = os.path.realpath(args.save_cam_conf_json)
+    print("getSaveCamConfJson: saving to {}".format(jsonfile))
+    camera = gp.Camera()
+    hasCamInited = False
+    try:
+        camera.init() # prints: WARNING: gphoto2: (b'gp_context_error') b'Could not detect any camera' if logging set up
+        hasCamInited = True
+    except Exception as ex:
+        lastException = ex
+        print("No camera: {} {}; ".format( type(lastException).__name__, lastException.args))
+        #if type(ex) == gp.GPhoto2Error: #gphoto2.GPhoto2Error:
+        #    pass
+    if hasCamInited:
+        camera_config = camera.get_config() # may print: WARNING: gphoto2: (b'_get_config [config.c:7649]') b"Type of property 'Owner Name' expected: 0x4002 got: 0x0000"
+        #print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
+        camconfobj = get_camera_config_object(camera_config)
+        with open(jsonfile, 'wb') as f: # SO:14870531
+            # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
+            json.dump(camconfobj, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
+        print("Saved config to {}; exiting.".format(jsonfile))
+        sys.exit(0)
+    else: # camera not inited
+        print("Sorry, no camera present, cannot execute command; exiting.")
+        sys.exit(1)
+
+def copyFilterCamConfJson(args):
+    if (not(args.load_cam_conf_json) or not(args.save_cam_conf_json)):
+        print("copyFilterCamConfJson: Sorry, unusable/empty input or output .json filename; aborting")
+        sys.exit(1)
+    injsonfile = os.path.realpath(args.load_cam_conf_json)
+    outjsonfile = os.path.realpath(args.save_cam_conf_json)
+    print("loadSetCamConfJson: input load from {}, output save to {}".format(injsonfile, outjsonfile))
+    # no need for camera here
+    # open and parse injsonfile as object
+    with open(injsonfile) as in_data_file:
+        indatadict = json.load(in_data_file, object_pairs_hook=OrderedDict)
+    # check filters
+    jsonfilters = get_json_filters(args)
+    jsonfilterslen = len(jsonfilters)
+    if jsonfilterslen > 0:
+        print("Got {} json filters; including only properties names(/values) in filters in output file".format(jsonfilterslen))
+    else:
+        print("Got no ({}) json filters; copying input (flattened) to output file".format(jsonfilterslen))
+    retdict = OrderedDict()
+    retdict['camera_model'] = indatadict['camera_model']
+    retdict['orig_ts_taken_on'] = indatadict['ts_taken_on']
+    retdict['orig_date_taken_on'] = indatadict['date_taken_on']
+    unixts, isots, fsuffts = get_formatted_ts( time.time() )
+    retdict['ts_taken_on'] = unixts
+    retdict['date_taken_on'] = isots
+    inpropcount = PropCount()
+    outpropcount = PropCount()
+    retdict['children'] = []
+    copy_json_filter_props(indatadict['children'], retdict['children'], inpropcount, outpropcount, jsonfilters)
+    print("Processed input props: {} ro, {} rw, {} total; got output props: {} ro, {} rw, {} total".format(
+        inpropcount.numro, inpropcount.numrw, inpropcount.numtot, outpropcount.numro, outpropcount.numrw, outpropcount.numtot
+    ))
+    # save
+    with open(outjsonfile, 'wb') as f: # SO:14870531
+        # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
+        json.dump(retdict, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
+    print("Saved filtered copy to output file {}".format(outjsonfile))
+    sys.exit(0)
+
+def loadSetCamConfJson(args):
+    if (not(args.load_cam_conf_json)):
+        print("loadSetCamConfJson: Sorry, unusable/empty output .json filename; aborting")
+        sys.exit(1)
+    injsonfile = os.path.realpath(args.load_cam_conf_json)
+    print("loadSetCamConfJson: loading from {}".format(injsonfile))
+    camera = gp.Camera()
+    ctx = gp.Context()
+    hasCamInited = False
+    try:
+        #camera.init() # prints: WARNING: gphoto2: (b'gp_context_error') b'Could not detect any camera' if logging set up
+        # do init with ctx for wait_for_event; see https://github.com/jim-easterbrook/python-gphoto2/issues/29
+        camera.init(ctx)
+        hasCamInited = True
+    except Exception as ex:
+        lastException = ex
+        print("No camera: {} {}; ".format( type(lastException).__name__, lastException.args))
+        #if type(ex) == gp.GPhoto2Error: #gphoto2.GPhoto2Error:
+        #    pass
+    if hasCamInited:
+        camera_config = camera.get_config()
+        ## get the camera model
+        #camera_model = get_camera_model(camera_config)
+        #put_camera_capture_preview_mirror(camera, camera_config, camera_model)
+        injsonfile = os.path.realpath(args.load_cam_conf_json)
+        # open and parse injsonfile as object
+        with open(injsonfile) as in_data_file:
+            indatadict = json.load(in_data_file, object_pairs_hook=OrderedDict)
+        print("Getting flattened object (removes hierarchy/nodes with only children and without value) from {} ...".format(injsonfile))
+        inpropcount = PropCount()
+        outpropcount = PropCount()
+        jsonfilters = [] # empty here
+        flatproparray = []
+        copy_json_filter_props(indatadict['children'], flatproparray, inpropcount, outpropcount, jsonfilters)
+        print("Flattened {} ro, {} rw, {} total input props to: {} ro, {} rw, {} total flat props".format(
+            inpropcount.numro, inpropcount.numrw, inpropcount.numtot, outpropcount.numro, outpropcount.numrw, outpropcount.numtot
+        ))
+        print("Applying at most {} read/write props (ignoring {} read-only ones, out of {} total props) to camera:".format(
+            outpropcount.numrw, outpropcount.numro, len(flatproparray)
+        ))
+        numappliedprops = 0
+        usedlabels = [] ; usednames = []
+        # NOTE - some of the camera properties depend on others;
+        # say for shootingmode=Manual, some vars are r/w, but for shootingmode=Auto, same vars become r/o
+        # thus we split off flatproparray in two parts, executed first the one, then the other
+        flatproparrayfirst = []
+        for iname in PROPNAMESTOSETFIRST: # SO: 54343917
+            # find the object having the name iname
+            foundidx = -1
+            for ix, idict in enumerate(flatproparray):
+                if idict.get('name') == iname:
+                    foundidx = ix
+                    break
+            if foundidx > -1:
+                # remove dict object via pop at index, save removed object
+                remdict = flatproparray.pop(foundidx)
+                # add removed object to newarr:
+                flatproparrayfirst.append(remdict)
+        print("First pass (of applying cam settings):")
+        usednamesfirst = []
+        passedpropsfirst = 0
+        # no need to check duplicates or blacklisted here:
+        for ix, tprop in enumerate(flatproparrayfirst):
+            if tprop['ro'] == 1:
+                print(" {:3d}: (ignoring read-only prop '{}' ({}))".format(ix+1, tprop['name'], tprop['label'] ))
+            else:
+                numappliedprops += 1
+                print(" {:3d}: Applying prop {}/{}: '{}' = '{}' ({}))".format(ix+1, numappliedprops, outpropcount.numrw, tprop['name'], tprop['value'], tprop['label']))
+                usedlabels.append(tprop['label'])
+                #usednames.append(tprop['name'])
+                usednamesfirst.append(tprop['name'])
+                # note, if tprop['name'] or a Python var is directly used, getting:
+                # TypeError: in method 'gp_widget_get_child_by_name', argument 2 of type 'char const *'
+                # "{}".format(tprop['name']) gets around this error
+                OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "{}".format(tprop['name']) )
+                if OK >= gp.GP_OK:
+                    # note that sometimes TypeError: in method 'CameraWidget_set_value', argument 2 of type 'int'
+                    # tprop['value'] can be int, or str in Python 3/unicode in Python 2; when unicode, must be reformatted into string with "{}".format(), else TypeError: in method 'CameraWidget_set_value', argument 2 of type 'char const *'
+                    if ( type(tprop['value']).__name__ == "unicode" ):
+                        gpprop.set_value( "{}".format(tprop['value']) )
+                    else:
+                        gpprop.set_value( tprop['value'] )
+            passedpropsfirst = ix+1
+        print("  applying props: {}.".format(",".join(usednamesfirst)))
+        camera.set_config(camera_config) # must have this, else value is not effectuated!
+        # Note: out here, even if set_config returned, we might still have the old props readonly values
+        #for ix in range(100):
+        #    OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "exposurecompensation" )
+        #    if OK >= gp.GP_OK:
+        #        print(gpprop.get_readonly())
+        # when actually changing property, the wait_for_event blocking might take longer than the whole timeout (a second), and will print "[2, <Swig Object of type 'CameraFilePath *' at 0x7fbbaf971a40>]"
+        # when not changing property, wait_for_event will exit more quickly (but still wait the whole timeout (a second)), and will print "[1, None]"
+        # however, when changing property with wait_for_event, camera takes a picture, too?! [waiting for variables to update, and wait_for_event causing picture to be taken? · Issue #75 · jim-easterbrook/python-gphoto2 · GitHub](https://github.com/jim-easterbrook/python-gphoto2/issues/75)
+        #print(camera.wait_for_event(1000, ctx)) # or gp.gp_camera_wait_for_event(camera,1000,ctx)
+        #camera_config = camera.get_config() # redoing get_config instead of sleep/wait does not get rid of "Sorry, the property ... is currently read-only."
+        # sleeping for 5 sec seems enough to allow changes between auto and manual shootingmode, without taking a picture... but 1 sec is not; 3 seems enough..
+        # so just do time.sleep for now - 2 sec seems enough
+        time.sleep(2)
+        print("Second pass (of applying cam settings):")
+        for ix, tprop in enumerate(flatproparray):
+            propnum = passedpropsfirst + ix + 1
+            if tprop['ro'] == 1:
+                print(" {:3d}: (ignoring read-only prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
+            # duplicate label has to handle not just equal labels, but also "White Balance" in "WhiteBalance", and "Shooting Mode" in "Canon Shooting Mode"
+            # but it should not confuse "Capture" with "Capture Target"
+            #elif ( (tprop['label'] in '\t'.join(usedlabels)) or (tprop['label'].replace(' ','') in '\t'.join(usedlabels)) ):
+            # so, only look for exact duplicates - rest, if needed, can be blacklisted:
+            elif ( tprop['label'] in usedlabels ):
+                print(" {:3d}: (ignoring duplicate label prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
+            elif ( any([pat.match(tprop['name']) for pat in BLACKLISTPROPSREGEX]) ):
+                print(" {:3d}: (ignoring blacklisted name prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
+            else:
+                numappliedprops += 1
+                print(" {:3d}: Applying prop {}/{}: '{}' = '{}' ({}))".format(propnum, numappliedprops, outpropcount.numrw, tprop['name'], tprop['value'], tprop['label']))
+                usedlabels.append(tprop['label'])
+                usednames.append(tprop['name'])
+                OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "{}".format(tprop['name']) )
+                if OK >= gp.GP_OK:
+                    if ( type(tprop['value']).__name__ == "unicode" ):
+                        gpprop.set_value( "{}".format(tprop['value']) )
+                    else:
+                        gpprop.set_value( tprop['value'] )
+        print("  applying props: {} (+ {}).".format( ",".join(usednames), ",".join(usednamesfirst) ))
+        camera.set_config(camera_config) # must have this, else value is not effectuated!
+        print("Applied {} properties from file {} to camera; exiting.".format(numappliedprops, injsonfile))
+        sys.exit(0)
+    else: # camera not inited
+        print("Sorry, no camera present, cannot execute command; exiting.")
+        sys.exit(1)
+
+
 # SO:35514531 - see also SO:46934526, 40683840, 9475772, https://github.com/baoboa/pyqt5/blob/master/examples/widgets/imageviewer.py
 class PhotoViewer(QtWidgets.QGraphicsView):
     photoClicked = QtCore.pyqtSignal(QtCore.QPoint)
@@ -805,203 +1004,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.pixmap = QtGui.QPixmap.fromImage(self.q_image)
         self.image_display.setPhoto(self.pixmap)
 
-def getSaveCamConfJson(args):
-    if (not(args.save_cam_conf_json)):
-        print("getSaveCamConfJson: Sorry, unusable/empty output .json filename; aborting")
-        sys.exit(1)
-    jsonfile = os.path.realpath(args.save_cam_conf_json)
-    print("getSaveCamConfJson: saving to {}".format(jsonfile))
-    camera = gp.Camera()
-    hasCamInited = False
-    try:
-        camera.init() # prints: WARNING: gphoto2: (b'gp_context_error') b'Could not detect any camera' if logging set up
-        hasCamInited = True
-    except Exception as ex:
-        lastException = ex
-        print("No camera: {} {}; ".format( type(lastException).__name__, lastException.args))
-        #if type(ex) == gp.GPhoto2Error: #gphoto2.GPhoto2Error:
-        #    pass
-    if hasCamInited:
-        camera_config = camera.get_config() # may print: WARNING: gphoto2: (b'_get_config [config.c:7649]') b"Type of property 'Owner Name' expected: 0x4002 got: 0x0000"
-        #print(camera_config) # <Swig Object of type '_CameraWidget *' at 0x7fac9b6e53e8>
-        camconfobj = get_camera_config_object(camera_config)
-        with open(jsonfile, 'wb') as f: # SO:14870531
-            # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
-            json.dump(camconfobj, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
-        print("Saved config to {}; exiting.".format(jsonfile))
-        sys.exit(0)
-    else: # camera not inited
-        print("Sorry, no camera present, cannot execute command; exiting.")
-        sys.exit(1)
-
-def copyFilterCamConfJson(args):
-    if (not(args.load_cam_conf_json) or not(args.save_cam_conf_json)):
-        print("copyFilterCamConfJson: Sorry, unusable/empty input or output .json filename; aborting")
-        sys.exit(1)
-    injsonfile = os.path.realpath(args.load_cam_conf_json)
-    outjsonfile = os.path.realpath(args.save_cam_conf_json)
-    print("loadSetCamConfJson: input load from {}, output save to {}".format(injsonfile, outjsonfile))
-    # no need for camera here
-    # open and parse injsonfile as object
-    with open(injsonfile) as in_data_file:
-        indatadict = json.load(in_data_file, object_pairs_hook=OrderedDict)
-    # check filters
-    jsonfilters = get_json_filters(args)
-    jsonfilterslen = len(jsonfilters)
-    if jsonfilterslen > 0:
-        print("Got {} json filters; including only properties names(/values) in filters in output file".format(jsonfilterslen))
-    else:
-        print("Got no ({}) json filters; copying input (flattened) to output file".format(jsonfilterslen))
-    retdict = OrderedDict()
-    retdict['camera_model'] = indatadict['camera_model']
-    retdict['orig_ts_taken_on'] = indatadict['ts_taken_on']
-    retdict['orig_date_taken_on'] = indatadict['date_taken_on']
-    unixts, isots, fsuffts = get_formatted_ts( time.time() )
-    retdict['ts_taken_on'] = unixts
-    retdict['date_taken_on'] = isots
-    inpropcount = PropCount()
-    outpropcount = PropCount()
-    retdict['children'] = []
-    copy_json_filter_props(indatadict['children'], retdict['children'], inpropcount, outpropcount, jsonfilters)
-    print("Processed input props: {} ro, {} rw, {} total; got output props: {} ro, {} rw, {} total".format(
-        inpropcount.numro, inpropcount.numrw, inpropcount.numtot, outpropcount.numro, outpropcount.numrw, outpropcount.numtot
-    ))
-    # save
-    with open(outjsonfile, 'wb') as f: # SO:14870531
-        # add separators if indent is not none for python2, [Issue 16333: Trailing whitespace in json dump when using indent](https://bugs.python.org/issue16333)
-        json.dump(retdict, codecs.getwriter('utf-8')(f), ensure_ascii=False, indent=2, separators=(',', ': '))
-    print("Saved filtered copy to output file {}".format(outjsonfile))
-    sys.exit(0)
-
-def loadSetCamConfJson(args):
-    if (not(args.load_cam_conf_json)):
-        print("loadSetCamConfJson: Sorry, unusable/empty output .json filename; aborting")
-        sys.exit(1)
-    injsonfile = os.path.realpath(args.load_cam_conf_json)
-    print("loadSetCamConfJson: loading from {}".format(injsonfile))
-    camera = gp.Camera()
-    ctx = gp.Context()
-    hasCamInited = False
-    try:
-        #camera.init() # prints: WARNING: gphoto2: (b'gp_context_error') b'Could not detect any camera' if logging set up
-        # do init with ctx for wait_for_event; see https://github.com/jim-easterbrook/python-gphoto2/issues/29
-        camera.init(ctx)
-        hasCamInited = True
-    except Exception as ex:
-        lastException = ex
-        print("No camera: {} {}; ".format( type(lastException).__name__, lastException.args))
-        #if type(ex) == gp.GPhoto2Error: #gphoto2.GPhoto2Error:
-        #    pass
-    if hasCamInited:
-        camera_config = camera.get_config()
-        ## get the camera model
-        #camera_model = get_camera_model(camera_config)
-        #put_camera_capture_preview_mirror(camera, camera_config, camera_model)
-        injsonfile = os.path.realpath(args.load_cam_conf_json)
-        # open and parse injsonfile as object
-        with open(injsonfile) as in_data_file:
-            indatadict = json.load(in_data_file, object_pairs_hook=OrderedDict)
-        print("Getting flattened object (removes hierarchy/nodes with only children and without value) from {} ...".format(injsonfile))
-        inpropcount = PropCount()
-        outpropcount = PropCount()
-        jsonfilters = [] # empty here
-        flatproparray = []
-        copy_json_filter_props(indatadict['children'], flatproparray, inpropcount, outpropcount, jsonfilters)
-        print("Flattened {} ro, {} rw, {} total input props to: {} ro, {} rw, {} total flat props".format(
-            inpropcount.numro, inpropcount.numrw, inpropcount.numtot, outpropcount.numro, outpropcount.numrw, outpropcount.numtot
-        ))
-        print("Applying at most {} read/write props (ignoring {} read-only ones, out of {} total props) to camera:".format(
-            outpropcount.numrw, outpropcount.numro, len(flatproparray)
-        ))
-        numappliedprops = 0
-        usedlabels = [] ; usednames = []
-        # NOTE - some of the camera properties depend on others;
-        # say for shootingmode=Manual, some vars are r/w, but for shootingmode=Auto, same vars become r/o
-        # thus we split off flatproparray in two parts, executed first the one, then the other
-        flatproparrayfirst = []
-        for iname in PROPNAMESTOSETFIRST: # SO: 54343917
-            # find the object having the name iname
-            foundidx = -1
-            for ix, idict in enumerate(flatproparray):
-                if idict.get('name') == iname:
-                    foundidx = ix
-                    break
-            if foundidx > -1:
-                # remove dict object via pop at index, save removed object
-                remdict = flatproparray.pop(foundidx)
-                # add removed object to newarr:
-                flatproparrayfirst.append(remdict)
-        print("First pass (of applying cam settings):")
-        usednamesfirst = []
-        passedpropsfirst = 0
-        # no need to check duplicates or blacklisted here:
-        for ix, tprop in enumerate(flatproparrayfirst):
-            if tprop['ro'] == 1:
-                print(" {:3d}: (ignoring read-only prop '{}' ({}))".format(ix+1, tprop['name'], tprop['label'] ))
-            else:
-                numappliedprops += 1
-                print(" {:3d}: Applying prop {}/{}: '{}' = '{}' ({}))".format(ix+1, numappliedprops, outpropcount.numrw, tprop['name'], tprop['value'], tprop['label']))
-                usedlabels.append(tprop['label'])
-                #usednames.append(tprop['name'])
-                usednamesfirst.append(tprop['name'])
-                # note, if tprop['name'] or a Python var is directly used, getting:
-                # TypeError: in method 'gp_widget_get_child_by_name', argument 2 of type 'char const *'
-                # "{}".format(tprop['name']) gets around this error
-                OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "{}".format(tprop['name']) )
-                if OK >= gp.GP_OK:
-                    # note that sometimes TypeError: in method 'CameraWidget_set_value', argument 2 of type 'int'
-                    # tprop['value'] can be int, or str in Python 3/unicode in Python 2; when unicode, must be reformatted into string with "{}".format(), else TypeError: in method 'CameraWidget_set_value', argument 2 of type 'char const *'
-                    if ( type(tprop['value']).__name__ == "unicode" ):
-                        gpprop.set_value( "{}".format(tprop['value']) )
-                    else:
-                        gpprop.set_value( tprop['value'] )
-            passedpropsfirst = ix+1
-        print("  applying props: {}.".format(",".join(usednamesfirst)))
-        camera.set_config(camera_config) # must have this, else value is not effectuated!
-        # Note: out here, even if set_config returned, we might still have the old props readonly values
-        #for ix in range(100):
-        #    OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "exposurecompensation" )
-        #    if OK >= gp.GP_OK:
-        #        print(gpprop.get_readonly())
-        # when actually changing property, the wait_for_event blocking might take longer than the whole timeout (a second), and will print "[2, <Swig Object of type 'CameraFilePath *' at 0x7fbbaf971a40>]"
-        # when not changing property, wait_for_event will exit more quickly (but still wait the whole timeout (a second)), and will print "[1, None]"
-        # however, when changing property with wait_for_event, camera takes a picture, too?! [waiting for variables to update, and wait_for_event causing picture to be taken? · Issue #75 · jim-easterbrook/python-gphoto2 · GitHub](https://github.com/jim-easterbrook/python-gphoto2/issues/75)
-        #print(camera.wait_for_event(1000, ctx)) # or gp.gp_camera_wait_for_event(camera,1000,ctx)
-        #camera_config = camera.get_config() # redoing get_config instead of sleep/wait does not get rid of "Sorry, the property ... is currently read-only."
-        # sleeping for 5 sec seems enough to allow changes between auto and manual shootingmode, without taking a picture... but 1 sec is not; 3 seems enough..
-        # so just do time.sleep for now - 2 sec seems enough
-        time.sleep(2)
-        print("Second pass (of applying cam settings):")
-        for ix, tprop in enumerate(flatproparray):
-            propnum = passedpropsfirst + ix + 1
-            if tprop['ro'] == 1:
-                print(" {:3d}: (ignoring read-only prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
-            # duplicate label has to handle not just equal labels, but also "White Balance" in "WhiteBalance", and "Shooting Mode" in "Canon Shooting Mode"
-            # but it should not confuse "Capture" with "Capture Target"
-            #elif ( (tprop['label'] in '\t'.join(usedlabels)) or (tprop['label'].replace(' ','') in '\t'.join(usedlabels)) ):
-            # so, only look for exact duplicates - rest, if needed, can be blacklisted:
-            elif ( tprop['label'] in usedlabels ):
-                print(" {:3d}: (ignoring duplicate label prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
-            elif ( any([pat.match(tprop['name']) for pat in BLACKLISTPROPSREGEX]) ):
-                print(" {:3d}: (ignoring blacklisted name prop '{}' ({}))".format(propnum, tprop['name'], tprop['label'] ))
-            else:
-                numappliedprops += 1
-                print(" {:3d}: Applying prop {}/{}: '{}' = '{}' ({}))".format(propnum, numappliedprops, outpropcount.numrw, tprop['name'], tprop['value'], tprop['label']))
-                usedlabels.append(tprop['label'])
-                usednames.append(tprop['name'])
-                OK, gpprop = gp.gp_widget_get_child_by_name( camera_config, "{}".format(tprop['name']) )
-                if OK >= gp.GP_OK:
-                    if ( type(tprop['value']).__name__ == "unicode" ):
-                        gpprop.set_value( "{}".format(tprop['value']) )
-                    else:
-                        gpprop.set_value( tprop['value'] )
-        print("  applying props: {} (+ {}).".format( ",".join(usednames), ",".join(usednamesfirst) ))
-        camera.set_config(camera_config) # must have this, else value is not effectuated!
-        print("Applied {} properties from file {} to camera; exiting.".format(numappliedprops, injsonfile))
-        sys.exit(0)
-    else: # camera not inited
-        print("Sorry, no camera present, cannot execute command; exiting.")
-        sys.exit(1)
 
 def main():
     # set up logging

--- a/examples/cam-conf-view-gui.py
+++ b/examples/cam-conf-view-gui.py
@@ -189,7 +189,7 @@ def start_capture_view():
         camera_config = camera.get_config()
         camera_model = get_camera_model(camera_config)
         put_camera_capture_preview_mirror(camera, camera_config, camera_model)
-        print("Started capture view (raised mirror) on camera: {}".format(camera_model))
+        print("Started capture view (extended lens/raised mirror) on camera: {}".format(camera_model))
         sys.exit(0)
     else: # camera not inited
         print("Sorry, no camera present, cannot execute command; exiting.")
@@ -209,9 +209,14 @@ def stop_capture_view():
         camera_model = get_camera_model(camera_config)
         # NOTE: for Canon S3 IS, getting: -2 None; and also
         # `gphoto2 --set-config viewfinder=0`: Error: viewfinder not found in configuration tree.
+        #OK, viewfinder = gp.gp_widget_get_child_by_name( camera_config, 'viewfinder' )
         # https://github.com/gphoto/gphoto2/issues/195
-        OK, viewfinder = gp.gp_widget_get_child_by_name( camera_config, 'viewfinder' )
-        print("{} {}".format(OK, viewfinder))
+        # `gphoto2 --set-config capture=0` works to retract the lens, however
+        OK, capture = gp.gp_widget_get_child_by_name( camera_config, 'capture' )
+        if OK >= gp.GP_OK:
+            capture.set_value(0)
+            camera.set_config(camera_config) # must have this, else value is not effectuated!
+        print("Stopped capture view (retracted lens/released mirror) on camera: {} ({} {})".format(camera_model, OK, capture))
         sys.exit(0)
     else: # camera not inited
         print("Sorry, no camera present, cannot execute command; exiting.")


### PR DESCRIPTION
This example app imports from `examples/camera-config-gui-oo.py`, and thus I believe it should be submitted here.

I was missing a gphoto2 app, that can:

* Load and save camera settings into a text file - here .json - also from command line mode
* Allows for zoom and drag into the preview window, regardless of how small its resolution is

Here is an animated .gif of a screen capture of how the GUI looks like, when there is no camera attached - basically shows the zoom/drag functionality of the viewer:

![simplescreenrecorder-cam-conf-view-gui-2019-02-19_21 44 14-opt](https://user-images.githubusercontent.com/26737749/53056988-a2649c80-34ad-11e9-8fe5-cdcad008c905.gif)

Attached is also a .zip of a .mp4 video of the GUI, when there is camera attached: [simplescreenrecorder-cam-conf-view-gui-2019-02-19_22.00.19.mp4.zip](https://github.com/jim-easterbrook/python-gphoto2/files/2882482/simplescreenrecorder-cam-conf-view-gui-2019-02-19_22.00.19.mp4.zip); for reference, here is a screenshot of that video:

![simplescreenrecorder-cam-conf-view-gui-2019-02-19_22 00 19](https://user-images.githubusercontent.com/26737749/53057116-3c2c4980-34ae-11e9-8a57-dfca4e894f93.png)

Note that the properties window taken from `camera-config-gui-oo.py` changes each time a property has its value changed, and thus helps with understanding that some camera variables only appear in certain contexts (e.g. when camera is set to Manual). Also, most of the properties are either read-only, or you probably don't want to change them arbitrarily, thus command line mode includes property name blacklist, as well as a command for filtering (which will extract only the requested properties from a .json save file, which otherwise contains the entire hierarchy of properties reported by gphoto2).

One pretty much has to set the camera in Capture mode, to get to change relevant properties from the GUI. The script is not extensively tested, so breakage may occur, - but generally works, as shown in the video, tested with Canon S3 IS.
