### PR TITLE
Add requirements.txt for examples scripts

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -4,3 +4,11 @@ Examples
 This directory contains several example programs illustrating various aspects of using `python-gphoto2`.
 Most of them are not intended to be complete or usable, they just show how to do one or two things.
 You will probably need to experiment quite a bit, and make some changes, to get them to work with your camera(s) and do what you want to do.
+
+Installing dependencies
+-----------------------
+
+Many of these example scripts require some Python dependencies. You can install all of them with::
+
+    pip install -r requirements.txt
+

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,6 @@
+ExifRead==2.1.2
+gphoto2==2.0.0
+Pillow==6.2.1
+PyQt5==5.13.1
+PyQt5-sip==12.7.0
+six==1.12.0


### PR DESCRIPTION
In this way new users can avoid all those annoying *No modules named xxx* errors in one command line.