### PR TITLE
Break from 'while True' if no files left to delete

### DIFF
--- a/examples/clear-space.py
+++ b/examples/clear-space.py
@@ -104,7 +104,7 @@ def main(argv=None):
         print('Camera has %.1f%% free space' % (
             100.0 * float(si.freekbytes) / float(si.capacitykbytes)))
         free_space = si.freekbytes
-        if free_space >= target:
+        if free_space >= target or len(files) == 0:
             break
     camera.exit()
     return 0


### PR DESCRIPTION
clear-space.py holds in a loop forever if you request more space be made than there are images on the camera.

This is probably only apparent if you run the script with the intent of deleting all images: 100 (%).

```python
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
Camera has 99.5% free space
```

... you get the gist.

This is a simple fix, but I think is sufficient? By all means reject and re-write if you'd prefer to see it done differently.

\- G.