### PR TITLE
fix build: only use first 2 items of setuptools.__version__.split('.')

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ setup_kwds = {
     'include_package_data': False,
     }
 
-if tuple(map(int, setuptools_version.split('.'))) < (61, 0):
+if tuple(map(int, setuptools_version.split('.')[:2])) < (61, 0):
     # get metadata from pyproject.toml
     import toml
     metadata = toml.load('pyproject.toml')


### PR DESCRIPTION
`setuptools.__version__.split('.')` can contain non digit strings, like `post0` eg:
`setuptools.__version__ = '68.2.2.post0'` which will create a ValueError when `post0` is passed to `int` when `setup.py` is run.

this change modifies setup.py so it only converts the first two items from `split('.')` to ints.