### PR TITLE
Reinstated CameraList iterator

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,7 +19,11 @@ License along with python-gphoto2.  If not, see
 <https://www.gnu.org/licenses/>.
 
 
+Changes in 2.6.1:
+  1/ Reinstated CameraList.__iter__ removed in v2.6.0, but deprecated.
+
 Changes in 2.6.0:
+  0/ API change: Removed CameraList.__iter__, use CameraList.items() instead.
   1/ Deprecated passing a CameraFile object to file_get() and capture_preview()
      functions. These allocate a new CameraFile object for the return value.
   2/ CameraWidget now has len and [] (index) methods.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-python-gphoto2 v\ 2.6.0
+python-gphoto2 v\ 2.6.1
 =======================
 
 python-gphoto2 is a comprehensive Python interface (or binding) to libgphoto2_.

--- a/src/gphoto2/list.i
+++ b/src/gphoto2/list.i
@@ -1,6 +1,6 @@
 // python-gphoto2 - Python interface to libgphoto2
 // http://github.com/jim-easterbrook/python-gphoto2
-// Copyright (C) 2014-24  Jim Easterbrook  jim@jim-easterbrook.me.uk
+// Copyright (C) 2014-25  Jim Easterbrook  jim@jim-easterbrook.me.uk
 //
 // This file is part of python-gphoto2.
 //
@@ -145,6 +145,10 @@ typedef struct _CameraList_accessor {} CameraList_accessor;
 // Make CameraList more like a Python list and/or dict
 %feature("python:slot", "mp_subscript", functype="binaryfunc")
   _CameraList::__getitem__;
+%feature("python:slot", "tp_iter", functype="getiterfunc")
+  _CameraList::__iter__;
+// deprecated since 2025-06-03, v2.6.1
+DEPRECATED(_CameraList::__iter__, 1)
 %feature("docstring") _CameraList::keys "Return an accessor for the names in the list."
 %feature("docstring") _CameraList::values "Return an accessor for the values in the list."
 %feature("docstring") _CameraList::items "Return an accessor for the (name, value) pairs in the list."
@@ -181,6 +185,11 @@ typedef struct _CameraList_accessor {} CameraList_accessor;
   }
   CameraList_accessor* items() {
     return new_CameraList_accessor($self, CameraList_get_item);
+  }
+  PyObject* __iter__() {
+    return PySeqIter_New(SWIG_Python_NewPointerObj(
+      NULL, SWIG_as_voidptr(_CameraList_items($self)),
+      $descriptor(CameraList_accessor*), SWIG_POINTER_OWN));
   }
 };
 

--- a/src/swig-gp2_5_31/__init__.py
+++ b/src/swig-gp2_5_31/__init__.py
@@ -1,5 +1,5 @@
-__version__ = "2.6.0"
-__version_tuple__ = tuple((2, 6, 0))
+__version__ = "2.6.1"
+__version_tuple__ = tuple((2, 6, 1))
 
 
 import os

--- a/src/swig-gp2_5_31/list_wrap.c
+++ b/src/swig-gp2_5_31/list_wrap.c
@@ -4388,6 +4388,11 @@ SWIGINTERN CameraList_accessor *_CameraList_values(struct _CameraList *self){
 SWIGINTERN CameraList_accessor *_CameraList_items(struct _CameraList *self){
     return new_CameraList_accessor(self, CameraList_get_item);
   }
+SWIGINTERN PyObject *_CameraList___iter__(struct _CameraList *self){
+    return PySeqIter_New(SWIG_Python_NewPointerObj(
+      NULL, SWIG_as_voidptr(_CameraList_items(self)),
+      SWIGTYPE_p__CameraList_accessor, SWIG_POINTER_OWN));
+  }
 SWIGINTERN int _CameraList___len__(struct _CameraList *self){
 
 
@@ -4783,6 +4788,34 @@ SWIGINTERN PyObject *_wrap_CameraList_items(PyObject *self, PyObject *args) {
   arg1 = (struct _CameraList *)(argp1);
   result = (CameraList_accessor *)_CameraList_items(arg1);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p__CameraList_accessor, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CameraList___iter__(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  struct _CameraList *arg1 = (struct _CameraList *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *result = 0 ;
+  
+  if (args && PyTuple_Check(args) && PyTuple_GET_SIZE(args) > 0) SWIG_exception_fail(SWIG_TypeError, "CameraList___iter__ takes no arguments");
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p__CameraList, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CameraList___iter__" "', argument " "1"" of type '" "struct _CameraList *""'"); 
+  }
+  arg1 = (struct _CameraList *)(argp1);
+  {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,"_CameraList::__iter__"" is deprecated and"
+        " will be removed in a future release", 1) < 0) SWIG_fail;
+    result = (PyObject *)_CameraList___iter__(arg1);
+    
+    if (PyErr_Occurred()) SWIG_fail;
+    
+  }
+  resultobj = result;
   return resultobj;
 fail:
   return NULL;
@@ -5196,6 +5229,8 @@ fail:
 SWIGPY_DESTRUCTOR_CLOSURE(_wrap_delete_CameraList) /* defines _wrap_delete_CameraList_destructor_closure */
 
 SWIGPY_BINARYFUNC_CLOSURE(_wrap_CameraList___getitem__) /* defines _wrap_CameraList___getitem___binaryfunc_closure */
+
+SWIGPY_GETITERFUNC_CLOSURE(_wrap_CameraList___iter__) /* defines _wrap_CameraList___iter___getiterfunc_closure */
 
 SWIGPY_LENFUNC_CLOSURE(_wrap_CameraList___len__) /* defines _wrap_CameraList___len___lenfunc_closure */
 
@@ -5975,6 +6010,10 @@ SWIGINTERN PyMethodDef SwigPyBuiltin___CameraList_methods[] = {
 		"items(self) -> CameraList_accessor\n"
 		"Return an accessor for the (name, value) pairs in the list.\n"
 		"" },
+  { "__iter__", _wrap_CameraList___iter__, METH_VARARGS, "\n"
+		"__iter__(self) -> PyObject *\n"
+		"This function is deprecated and will be removed in a future release.\n"
+		"" },
   { "__len__", _wrap_CameraList___len__, METH_VARARGS, "__len__(self) -> int" },
   { "count", _wrap_CameraList_count, METH_VARARGS, "\n"
 		"count(self) -> int\n"
@@ -6227,7 +6266,7 @@ static PyHeapTypeObject SwigPyBuiltin___CameraList_type = {
     (inquiry) 0,                            /* tp_clear */
     SwigPyBuiltin___CameraList_richcompare, /* tp_richcompare */
     0,                                      /* tp_weaklistoffset */
-    (getiterfunc) 0,                        /* tp_iter */
+    _wrap_CameraList___iter___getiterfunc_closure, /* tp_iter */
     (iternextfunc) 0,                       /* tp_iternext */
     SwigPyBuiltin___CameraList_methods,     /* tp_methods */
     0,                                      /* tp_members */
@@ -6444,7 +6483,7 @@ static PyTypeObject *SwigPyBuiltin___CameraList_type_create(PyTypeObject *type, 
     { Py_mp_length,                     (void *)(lenfunc) 0 },
     { Py_mp_subscript,                  (void *)_wrap_CameraList___getitem___binaryfunc_closure },
     { Py_mp_ass_subscript,              (void *)(objobjargproc) 0 },
-    { Py_tp_iter,                       (void *)(getiterfunc) 0 },
+    { Py_tp_iter,                       (void *)_wrap_CameraList___iter___getiterfunc_closure },
     { Py_tp_iternext,                   (void *)(iternextfunc) 0 },
     { Py_nb_add,                        (void *)(binaryfunc) 0 },
     { Py_nb_subtract,                   (void *)(binaryfunc) 0 },

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -69,6 +69,13 @@ class TestList(unittest.TestCase):
         self.assertEqual(test_list['A'], '1')
         with self.assertRaises(KeyError):
             test_list['Z']
+        with self.assertWarns(DeprecationWarning):
+            it = iter(test_list)
+        self.assertEqual(next(it), test_list[0])
+        self.assertEqual(next(it), test_list[1])
+        self.assertEqual(next(it), test_list[2])
+        with self.assertRaises(StopIteration):
+            next(it)
         it = iter(test_list.items())
         self.assertEqual(next(it), test_list[0])
         self.assertEqual(next(it), test_list[1])


### PR DESCRIPTION
This was removed in v2.6.0, but not deprecated in advance as any API change should be. see bug #188 for more details.